### PR TITLE
chore: Install Elasticsearch for CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   tests:
@@ -11,6 +14,20 @@ jobs:
     strategy:
       matrix:
         php: [8.0, 8.1]
+
+    services:
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.7.1
+        env:
+          discovery.type: single-node
+          ES_JAVA_OPTS: -Xms1024m -Xmx1538m
+        options: >-
+          --health-cmd "curl http://localhost:9200/_cluster/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+        ports:
+          - 9200:9200
 
     steps:
       - name: Checkout Code

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4",
+        "elasticsearch/elasticsearch": "^7.1",
         "hypefactors/php-code-standards": "^2.0",
         "phpunit/phpunit": "^9.0"
     },


### PR DESCRIPTION
This install Elasticsearch server + the PHP SDK as dev dependency.

Signed-off-by: Bruno Gaspar <brunofgaspar1@gmail.com>